### PR TITLE
Add files via upload

### DIFF
--- a/MapProcess/MapProcess/MapProcess.cpp
+++ b/MapProcess/MapProcess/MapProcess.cpp
@@ -148,6 +148,7 @@ MapProcess::MapProcess(string inputFilePath, string intermediateFilePath, string
 				th.join();
 			}
 		}
+		
 
 		// combine the files so that there is one for each process.
 		for (int i = 0; i < numberOfThreadsInt; i++) {
@@ -166,10 +167,7 @@ MapProcess::MapProcess(string inputFilePath, string intermediateFilePath, string
 			// erase the file contents and delete the file.
 			const char* interThreadFileChar = newIntermedThreadFilePath.c_str();
 
-			//Open file and then close to clear the contents
-			ofstream ofStreamObjNew;
-			fileManagementObjLocal.clearFile(ofStreamObjNew, newIntermedThreadFilePath);
-			remove(interThreadFileChar);
+		
 		}
 	}
 


### PR DESCRIPTION
Found a bug that it would delete all the words that had previously been completed and then move on to the next thread. This caused the output to only have the counts for the last file it read in. Deleted the part of Map Process that was clearing out the threads. In the new workflow.cpp I added a for loop to clear out the temp files that get created so it still gets cleaned up.